### PR TITLE
Allow conversion from ColoredString to Error

### DIFF
--- a/examples/as_error.rs
+++ b/examples/as_error.rs
@@ -1,0 +1,8 @@
+extern crate colored;
+
+use colored::Colorize;
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    Err("ERROR".red())?
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,24 @@
+use super::ColoredString;
+use std::{error::Error, fmt};
+
+pub struct ColoredStringError(pub ColoredString);
+
+impl ColoredStringError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0.to_string())
+    }
+}
+
+impl fmt::Display for ColoredStringError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.fmt(f)
+    }
+}
+
+impl fmt::Debug for ColoredStringError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.fmt(f)
+    }
+}
+
+impl Error for ColoredStringError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,12 @@ extern crate rspec;
 
 mod color;
 pub mod control;
+mod error;
 mod style;
 
 pub use color::*;
 
-use std::{borrow::Cow, fmt, ops::Deref};
+use std::{borrow::Cow, error::Error, fmt, ops::Deref};
 
 pub use style::{Style, Styles};
 
@@ -592,6 +593,12 @@ impl fmt::Display for ColoredString {
         escaped_input.fmt(f)?;
         f.write_str("\x1B[0m")?;
         Ok(())
+    }
+}
+
+impl From<ColoredString> for Box<dyn Error> {
+    fn from(cs: ColoredString) -> Box<dyn Error> {
+        Box::from(error::ColoredStringError(cs))
     }
 }
 


### PR DESCRIPTION
A string can be converted to a `Box<dyn Error>`, allowing something like
```rust
fn main() -> Result<(), Box<dyn Error>> {
    Err("ERROR")?
}
```

This PR also allows type conversion from `ColoredString` to `Box<dyn Error>`, so you can do
```rust
fn main() -> Result<(), Box<dyn Error>> {
    Err("ERROR".red())?
}
```
And get the expected styling in the error message (see added example).