### PR TITLE
Get closest color if TrueColor not supported

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, str::FromStr};
+use std::{borrow::Cow, env, str::FromStr};
 
 /// The 8 standard colors.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -23,6 +23,15 @@ pub enum Color {
     TrueColor { r: u8, g: u8, b: u8 },
 }
 
+fn truecolor_support() -> bool {
+    let truecolor = env::var("COLORTERM");
+    if let Ok(truecolor) = truecolor {
+        truecolor == "truecolor" || truecolor == "24bit"
+    } else {
+        false
+    }
+}
+
 #[allow(missing_docs)]
 impl Color {
     pub fn to_fg_str(&self) -> Cow<'static, str> {
@@ -43,6 +52,7 @@ impl Color {
             Color::BrightMagenta => "95".into(),
             Color::BrightCyan => "96".into(),
             Color::BrightWhite => "97".into(),
+            Color::TrueColor {..} if !truecolor_support() => self.closest_color_euclidean().to_fg_str(),
             Color::TrueColor { r, g, b } => format!("38;2;{};{};{}", r, g, b).into(),
         }
     }
@@ -65,6 +75,7 @@ impl Color {
             Color::BrightMagenta => "105".into(),
             Color::BrightCyan => "106".into(),
             Color::BrightWhite => "107".into(),
+            Color::TrueColor {..} if !truecolor_support() => self.closest_color_euclidean().to_bg_str(),
             Color::TrueColor { r, g, b } => format!("48;2;{};{};{}", r, g, b).into(),
         }
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -68,6 +68,75 @@ impl Color {
             Color::TrueColor { r, g, b } => format!("48;2;{};{};{}", r, g, b).into(),
         }
     }
+
+    /// Gets the closest plain color to the TrueColor
+    fn closest_color_euclidean(&self) -> Self {
+        use Color::*;
+        use std::cmp;
+
+        match *self {
+            TrueColor { r: r1, g: g1, b: b1 } => {
+                let colors = vec![
+                    Black,
+                    Red,
+                    Green,
+                    Yellow,
+                    Blue,
+                    Magenta,
+                    Cyan,
+                    White,
+                    BrightBlack,
+                    BrightRed,
+                    BrightGreen,
+                    BrightYellow,
+                    BrightBlue,
+                    BrightMagenta,
+                    BrightCyan,
+                    BrightWhite,
+                ].into_iter().map(|c| (c, c.into_truecolor()));
+                let distances = colors.map(|(c_original, c)| {
+                    if let TrueColor { r, g, b } = c {
+                        let rd = cmp::max(r, r1) - cmp::min(r, r1);
+                        let gd = cmp::max(g, g1) - cmp::min(g, g1);
+                        let bd = cmp::max(b, b1) - cmp::min(b, b1);
+                        let rd: u32 = rd.into();
+                        let gd: u32 = gd.into();
+                        let bd: u32 = bd.into();
+                        let distance = rd.pow(2) + gd.pow(2) + bd.pow(2);
+                        (c_original, distance)
+                    } else {
+                        unimplemented!("{:?} not a TrueColor", c)
+                    }
+                });
+                distances.min_by(|(_, d1), (_, d2)| d1.cmp(d2)).unwrap().0
+            }
+            c => c,
+        }
+
+    }
+
+    fn into_truecolor(self) -> Self {
+        use Color::*;
+        match self {
+            Black => TrueColor         { r: 0,   g: 0,   b: 0   },
+            Red => TrueColor           { r: 205, g: 0,   b: 0   },
+            Green => TrueColor         { r: 0,   g: 205, b: 0   },
+            Yellow => TrueColor        { r: 205, g: 205, b: 0   },
+            Blue => TrueColor          { r: 0,   g: 0,   b: 238 },
+            Magenta => TrueColor       { r: 205, g: 0,   b: 205 },
+            Cyan => TrueColor          { r: 0,   g: 205, b: 205 },
+            White => TrueColor         { r: 229, g: 229, b: 229 },
+            BrightBlack => TrueColor   { r: 127, g: 127, b: 127 },
+            BrightRed => TrueColor     { r: 255, g: 0,   b: 0   },
+            BrightGreen => TrueColor   { r: 0,   g: 255, b: 0   },
+            BrightYellow => TrueColor  { r: 255, g: 255, b: 0   },
+            BrightBlue => TrueColor    { r: 92,  g: 92,  b: 255 },
+            BrightMagenta => TrueColor { r: 255, g: 0,   b: 255 },
+            BrightCyan => TrueColor    { r: 0,   g: 255, b: 255 },
+            BrightWhite => TrueColor   { r: 255, g: 255, b: 255 },
+            TrueColor { r, g, b } => TrueColor { r, g, b },
+        }
+    }
 }
 
 impl<'a> From<&'a str> for Color {

--- a/src/color.rs
+++ b/src/color.rs
@@ -212,4 +212,37 @@ mod tests {
             assert_eq!(Err(()), color)
         }
     }
+
+    mod closest_euclidean {
+        use super::*;
+
+        macro_rules! make_euclidean_distance_test {
+            ( $test:ident : ( $r:literal, $g: literal, $b:literal ), $expected:expr ) => {
+                #[test]
+                fn $test() {
+                    let true_color = Color::TrueColor { r: $r, g: $g, b: $b };
+                    let actual = true_color.closest_color_euclidean();
+                    assert_eq!(actual, $expected);
+                }
+            }
+        }
+
+        make_euclidean_distance_test! { exact_black: (0, 0, 0), Color::Black }
+        make_euclidean_distance_test! { exact_red: (205, 0, 0), Color::Red }
+        make_euclidean_distance_test! { exact_green: (0, 205, 0), Color::Green }
+        make_euclidean_distance_test! { exact_yellow: (205, 205, 0), Color::Yellow }
+        make_euclidean_distance_test! { exact_blue: (0, 0, 238), Color::Blue }
+        make_euclidean_distance_test! { exact_magenta: (205, 0, 205), Color::Magenta }
+        make_euclidean_distance_test! { exact_cyan: (0, 205, 205), Color::Cyan }
+        make_euclidean_distance_test! { exact_white: (229, 229, 229), Color::White }
+
+        make_euclidean_distance_test! { almost_black: (10, 15, 10), Color::Black }
+        make_euclidean_distance_test! { almost_red: (215, 10, 10), Color::Red }
+        make_euclidean_distance_test! { almost_green: (10, 195, 10), Color::Green }
+        make_euclidean_distance_test! { almost_yellow: (195, 215, 10), Color::Yellow }
+        make_euclidean_distance_test! { almost_blue: (0, 0, 200), Color::Blue }
+        make_euclidean_distance_test! { almost_magenta: (215, 0, 195), Color::Magenta }
+        make_euclidean_distance_test! { almost_cyan: (10, 215, 215), Color::Cyan }
+        make_euclidean_distance_test! { almost_white: (209, 209, 229), Color::White }
+    }
 }


### PR DESCRIPTION
This PR makes TrueColor convert into one of the more "basic" colors (`Color::Black`, `Color::Red`, etc.) if TrueColor is not supported based on the `COLORTERM` environment variable. It gets the closest color based on Euclidean distance.

I'm not sure if some of the functions I added should be made public or not, so I left them private for now.