### PR TITLE
Add Serialize and Deserialize impls to Color under `serde` feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_script:
   - rustup component add clippy
 
 script:
-  - cargo test --verbose
-  - cargo clippy -- -Dwarnings
+  - cargo test --all-features --verbose
+  - cargo clippy --all-features -- -Dwarnings
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,12 @@ keywords = ["color", "string", "term", "ansi_term", "term-painter"]
 [features]
 # with this feature, no color will ever be written
 no-color = []
+serde = ["serde_crate/derive"]
 
 [dependencies]
 atty = "0.2"
 lazy_static = "1"
+serde_crate = { package = "serde", version = "1", optional = true }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,7 +1,15 @@
 use std::{borrow::Cow, str::FromStr};
 
+#[cfg(feature = "serde")]
+use serde_crate::*;
+
 /// The 8 standard colors.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[allow(missing_docs)]
 pub enum Color {
     Black,

--- a/src/control.rs
+++ b/src/control.rs
@@ -104,7 +104,7 @@ impl ShouldColorize {
     /// followed by `CLICOLOR` combined with tty check.
     pub fn from_env() -> Self {
         ShouldColorize {
-            clicolor: ShouldColorize::normalize_env(env::var("CLICOLOR")).unwrap_or_else(|| true)
+            clicolor: ShouldColorize::normalize_env(env::var("CLICOLOR")).unwrap_or(true)
                 && atty::is(atty::Stream::Stdout),
             clicolor_force: ShouldColorize::resolve_clicolor_force(
                 env::var("NO_COLOR"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ extern crate lazy_static;
 #[cfg(windows)]
 extern crate winapi;
 
+#[cfg(feature = "serde")]
+extern crate serde_crate;
+
 #[cfg(test)]
 extern crate rspec;
 


### PR DESCRIPTION
I have a use case where I want to serialize the whole struct with a color and currently there is no way to do that. This PR adds a feature `serde_derive` that adds derived implementations of `Serialize` and `Deserialize` traits to `Color`.