### PR TITLE
Document the current MSRV in the manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "colored"
 description = "The most simple way to add colors in your terminal"
 version = "2.0.2"
 edition = "2021"
+rust-version = "1.63"
 authors = ["Thomas Wickham <mackwic@gmail.com>"]
 license = "MPL-2.0"
 homepage = "https://github.com/mackwic/colored"


### PR DESCRIPTION
- Cargo will support MSRV aware dependency resolution in the future by relying on this field. Let's not rely on whatever heuristic it will use for crates not specifiying their MSRV.
- Clippy will not suggest changes that would require a newer version of Rust than specified. Important for not failing CI when applying the suggested change would force a raise of the MSRV.