### PR TITLE
Switch from `winapi` to `windows-sys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 2.0.4
+- Switch from `winapi` to `windows-sys`.
+
 # 2.0.3
 - Document crate MSRV of `1.63`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "colored"
 description = "The most simple way to add colors in your terminal"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2021"
 authors = ["Thomas Wickham <mackwic@gmail.com>"]
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,11 @@ no-color = []
 is-terminal = "0.4"
 lazy_static = "1"
 
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
-default-features = false
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.48"
 features = [
-    "consoleapi",
-    "processenv",
-    "winbase"
+    "Win32_Foundation",
+    "Win32_System_Console",
 ]
 
 [dev_dependencies]

--- a/src/control.rs
+++ b/src/control.rs
@@ -29,19 +29,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 #[allow(clippy::result_unit_err)]
 #[cfg(windows)]
 pub fn set_virtual_terminal(use_virtual: bool) -> Result<(), ()> {
-    use winapi::{
-        shared::minwindef::DWORD,
-        um::{
-            consoleapi::{GetConsoleMode, SetConsoleMode},
-            processenv::GetStdHandle,
-            winbase::STD_OUTPUT_HANDLE,
-            wincon::ENABLE_VIRTUAL_TERMINAL_PROCESSING,
-        },
+    use windows_sys::Win32::System::Console::{
+        GetConsoleMode, GetStdHandle, SetConsoleMode, ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+        STD_OUTPUT_HANDLE,
     };
 
     unsafe {
         let handle = GetStdHandle(STD_OUTPUT_HANDLE);
-        let mut original_mode: DWORD = 0;
+        let mut original_mode = 0;
         GetConsoleMode(handle, &mut original_mode);
 
         let enabled = original_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,6 @@
 extern crate is_terminal;
 #[macro_use]
 extern crate lazy_static;
-#[cfg(windows)]
-extern crate winapi;
 
 #[cfg(test)]
 extern crate rspec;


### PR DESCRIPTION
`winapi` is being phased out across the ecosystem in favor of `windows-sys`, which is maintained by Microsoft. Let's follow suit so dependents don't have to compile both.