### PR TITLE
Remove unnecessary is_terminal dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu", "windows", "macos"]
-        version: ["stable", "beta", "1.63"]
+        version: ["stable", "beta", "1.70"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Document crate MSRV of `1.70`.
 
 # 2.0.4
 - Switch from `winapi` to `windows-sys`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,13 @@ homepage = "https://github.com/mackwic/colored"
 repository = "https://github.com/mackwic/colored"
 readme = "README.md"
 keywords = ["color", "string", "term", "ansi_term", "term-painter"]
-rust-version = "1.63"
+rust-version = "1.70"
 
 [features]
 # with this feature, no color will ever be written
 no-color = []
 
 [dependencies]
-is-terminal = "0.4"
 lazy_static = "1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ providing a reference implementation, which greatly helped making this crate
 output correct strings.
 
 ## Minimum Supported Rust Version (MSRV)
-The current MSRV is `1.63`, which is checked and enforced automatically via CI. This version may change in the future in minor version bumps, so if you require a specific Rust version you should use a restricted version requirement such as `~X.Y`.
+The current MSRV is `1.70`, which is checked and enforced automatically via CI. This version may change in the future in minor version bumps, so if you require a specific Rust version you should use a restricted version requirement such as `~X.Y`.
 
 ## License
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,9 +1,8 @@
 //! A couple of functions to enable and disable coloring.
 
-use is_terminal::IsTerminal;
 use std::default::Default;
 use std::env;
-use std::io;
+use std::io::{self, IsTerminal};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Sets a flag to the console to use a virtual terminal environment.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@
 //!
 #![warn(missing_docs)]
 
-extern crate is_terminal;
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
Since Rust version 1.70.0, the built-in `IsTerminal` trait is now stabilized, which means that the `is_terminal` dependency is now unnecessary. However, this change also means that the version of the `rustc` compiler must to be greater than 1.70.0