### PR TITLE
Gradients and Rainbows

### DIFF
--- a/examples/colored_lists.rs
+++ b/examples/colored_lists.rs
@@ -1,0 +1,22 @@
+use colored::*;
+fn main() {
+    let no_colors = vec![];
+    let one_color = vec![Color::Red];
+    let two_colors = vec![Color::Blue, Color::Green];
+
+    println!("{}", "Text defaults to white".gradient(&no_colors));
+    println!("{}", "This text is red".gradient(&one_color));
+    println!("{}", "Transition from blue to green".gradient(&two_colors));
+    println!("{}", "A lot of the colors of the rainbow".rainbow());
+
+    println!("{}", "Transition from blue to green".on_gradient(&two_colors));
+    println!("{}", "A lot of the colors of the rainbow".on_rainbow());
+
+    //Test edge cases
+    println!("{}", "".gradient(&no_colors));
+    println!("{}", "a".gradient(&no_colors));
+    println!("{}", "b".gradient(&one_color));
+    println!("{}", "c".gradient(&two_colors));
+    println!("{}", "de".gradient(&two_colors));
+    println!("{}", "fg".gradient(&vec![Color::Green, Color::Violet, Color::Blue]));
+}

--- a/src/color.rs
+++ b/src/color.rs
@@ -12,6 +12,9 @@ pub enum Color {
     Magenta,
     Cyan,
     White,
+    Orange,
+    Indigo,
+    Violet,
     BrightBlack,
     BrightRed,
     BrightGreen,
@@ -35,6 +38,9 @@ impl Color {
             Color::Magenta => "35".into(),
             Color::Cyan => "36".into(),
             Color::White => "37".into(),
+            Color::Orange => format!("38;2;{};{};{}", 255, 165, 0).into(),
+            Color::Indigo => format!("38;2;{};{};{}", 75, 0, 130).into(),
+            Color::Violet => format!("38;2;{};{};{}", 238, 130, 238).into(),
             Color::BrightBlack => "90".into(),
             Color::BrightRed => "91".into(),
             Color::BrightGreen => "92".into(),
@@ -57,6 +63,9 @@ impl Color {
             Color::Magenta => "45".into(),
             Color::Cyan => "46".into(),
             Color::White => "47".into(),
+            Color::Orange => format!("48;2;{};{};{}", 255, 165, 0).into(),
+            Color::Indigo => format!("48;2;{};{};{}", 75, 0, 130).into(),
+            Color::Violet => format!("48;2;{};{};{}", 238, 130, 238).into(),
             Color::BrightBlack => "100".into(),
             Color::BrightRed => "101".into(),
             Color::BrightGreen => "102".into(),
@@ -66,6 +75,31 @@ impl Color {
             Color::BrightCyan => "106".into(),
             Color::BrightWhite => "107".into(),
             Color::TrueColor { r, g, b } => format!("48;2;{};{};{}", r, g, b).into(),
+        }
+    }
+
+    pub fn to_true_color(&self) -> Color {
+        match *self {
+            Color::Black => Color::TrueColor { r: 0, g: 0, b: 0 },
+            Color::Red => Color::TrueColor { r: 255, g: 0, b: 0 },
+            Color::Green => Color::TrueColor { r: 0, g: 255, b: 0 },
+            Color::Yellow => Color::TrueColor { r: 255, g: 255, b: 0 },
+            Color::Blue => Color::TrueColor { r: 0, g: 0, b: 255 },
+            Color::Magenta => Color::TrueColor { r: 255, g: 0, b: 255 },
+            Color::Cyan => Color::TrueColor { r: 0, g: 255, b: 255 },
+            Color::White => Color::TrueColor { r: 255, g: 255, b: 255 },
+            Color::Orange => Color::TrueColor { r: 255, g: 165, b: 0 },
+            Color::Indigo => Color::TrueColor { r: 75, g: 0, b: 130 },
+            Color::Violet => Color::TrueColor { r: 238, g: 130, b: 238 },
+            Color::BrightBlack => Color::TrueColor { r: 128, g: 128, b: 128 },
+            Color::BrightRed => Color::TrueColor { r: 255, g: 0, b: 0 },
+            Color::BrightGreen => Color::TrueColor { r: 0, g: 255, b: 0 },
+            Color::BrightYellow => Color::TrueColor { r: 255, g: 255, b: 0 },
+            Color::BrightBlue => Color::TrueColor { r: 0, g: 0, b: 255 },
+            Color::BrightMagenta => Color::TrueColor { r: 255, g: 0, b: 255 },
+            Color::BrightCyan => Color::TrueColor { r: 0, g: 255, b: 255 },
+            Color::BrightWhite => Color::TrueColor { r: 255, g: 255, b: 255 },
+            Color::TrueColor { .. } => *self, // If it's already TrueColor, just return it as is
         }
     }
 }
@@ -98,6 +132,9 @@ impl FromStr for Color {
             "purple" => Ok(Color::Magenta),
             "cyan" => Ok(Color::Cyan),
             "white" => Ok(Color::White),
+            "orange" => Ok(Color::Orange),
+            "indigo" => Ok(Color::Indigo),
+            "violet" => Ok(Color::Violet),
             "bright black" => Ok(Color::BrightBlack),
             "bright red" => Ok(Color::BrightRed),
             "bright green" => Ok(Color::BrightGreen),


### PR DESCRIPTION
Added support for two, three, or more colored gradients.
Added support for rainbows.

See example output
```
cargo run --example colored_lists
```