### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "Rust",
+    "image": "mcr.microsoft.com/vscode/devcontainers/rust:1",
+    "customizations": {
+        "vscode": {
+            "extensions": ["rust-lang.rust-analyzer"]
+        }
+    },
+    "remoteUser": "vscode"
+}


### PR DESCRIPTION
This file allows GitHub potential contributors to open this repository in GitHub Codespaces (I believe there are other services that use this file, but I'm most familiar with codespaces). This allows them to contribute to this project without cloning down the repo or even installing Rust, by instead working in a cloud-based development environment. You can think of it as a one-click setup to have all the tools you need to work on this repo. Personally, I use codespaces a lot to avoid cluttering up my local machine. Users can create their code space by clicking the "code" dropdown in their fork and switching to the "codespaces" tab.

This configuration sets up a simple container to install Rust and the `rust-analyzer` extension when a user is accessing the codespace via VS Code for the Web. You might want to update this configuration as this project gets more complex, for example using a Minimum Supported Rust Version or adding more extensions.