### PR TITLE
Replace `println!` calls with snapshot tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,6 @@
             "extensions": ["rust-lang.rust-analyzer"]
         }
     },
+    "postCreateCommand": "cargo install cargo-insta",
     "remoteUser": "vscode"
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.snap linguist-language=Text

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Run tests
 on: pull_request
-env: { CLICOLOR_FORCE: 1 }
+env:
+  CLICOLOR_FORCE: 1
+  COLORTERM: "truecolor"
 
 jobs:
   cargo-fmt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ features = [
 
 [dev_dependencies]
 ansi_term = "0.12"
+insta = "1"
 rspec = "=1.0.0-beta.3"

--- a/src/customcolors.rs
+++ b/src/customcolors.rs
@@ -26,10 +26,11 @@ impl From<(u8, u8, u8)> for CustomColor {
 #[cfg(test)]
 mod tests {
     use crate::*;
+    #[cfg_attr(feature = "no-color", ignore)]
     #[test]
     fn main() {
         let my_color = CustomColor::new(0, 120, 120);
-        println!("{}", "Greetings from Ukraine".custom_color(my_color));
+        insta::assert_display_snapshot!("Greetings from Ukraine".custom_color(my_color));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -640,6 +640,7 @@ impl From<ColoredString> for Box<dyn Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{fmt::Write, error::Error};
 
     #[test]
     fn formatting() {
@@ -653,47 +654,51 @@ mod tests {
     }
 
     #[test]
-    fn it_works() {
+    fn it_works() -> Result<(), Box<dyn Error>> {
+        let mut buf = String::new();
         let toto = "toto";
-        println!("{}", toto.red());
-        println!("{}", String::from(toto).red());
-        println!("{}", toto.blue());
+        writeln!(&mut buf, "{}", toto.red())?;
+        writeln!(&mut buf, "{}", String::from(toto).red())?;
+        writeln!(&mut buf, "{}", toto.blue())?;
 
-        println!("blue style ****");
-        println!("{}", toto.bold());
-        println!("{}", "yeah ! Red bold !".red().bold());
-        println!("{}", "yeah ! Yellow bold !".bold().yellow());
-        println!("{}", toto.bold().blue());
-        println!("{}", toto.blue().bold());
-        println!("{}", toto.blue().bold().underline());
-        println!("{}", toto.blue().italic());
-        println!("******");
-        println!("test clearing");
-        println!("{}", "red cleared".red().clear());
-        println!("{}", "bold cyan cleared".bold().cyan().clear());
-        println!("******");
-        println!("Bg tests");
-        println!("{}", toto.green().on_blue());
-        println!("{}", toto.on_magenta().yellow());
-        println!("{}", toto.purple().on_yellow());
-        println!("{}", toto.magenta().on_white());
-        println!("{}", toto.cyan().on_green());
-        println!("{}", toto.black().on_white());
-        println!("******");
-        println!("{}", toto.green());
-        println!("{}", toto.yellow());
-        println!("{}", toto.purple());
-        println!("{}", toto.magenta());
-        println!("{}", toto.cyan());
-        println!("{}", toto.white());
-        println!("{}", toto.white().red().blue().green());
-        println!("{}", toto.truecolor(255, 0, 0));
-        println!("{}", toto.truecolor(255, 255, 0));
-        println!("{}", toto.on_truecolor(0, 80, 80));
-        println!("{}", toto.custom_color((255, 255, 0)));
-        println!("{}", toto.on_custom_color((0, 80, 80)));
-        // uncomment to see term output
-        // assert!(false)
+        writeln!(&mut buf, "blue style ****")?;
+        writeln!(&mut buf, "{}", toto.bold())?;
+        writeln!(&mut buf, "{}", "yeah ! Red bold !".red().bold())?;
+        writeln!(&mut buf, "{}", "yeah ! Yellow bold !".bold().yellow())?;
+        writeln!(&mut buf, "{}", toto.bold().blue())?;
+        writeln!(&mut buf, "{}", toto.blue().bold())?;
+        writeln!(&mut buf, "{}", toto.blue().bold().underline())?;
+        writeln!(&mut buf, "{}", toto.blue().italic())?;
+        writeln!(&mut buf, "******")?;
+        writeln!(&mut buf, "test clearing")?;
+        writeln!(&mut buf, "{}", "red cleared".red().clear())?;
+        writeln!(&mut buf, "{}", "bold cyan cleared".bold().cyan().clear())?;
+        writeln!(&mut buf, "******")?;
+        writeln!(&mut buf, "Bg tests")?;
+        writeln!(&mut buf, "{}", toto.green().on_blue())?;
+        writeln!(&mut buf, "{}", toto.on_magenta().yellow())?;
+        writeln!(&mut buf, "{}", toto.purple().on_yellow())?;
+        writeln!(&mut buf, "{}", toto.magenta().on_white())?;
+        writeln!(&mut buf, "{}", toto.cyan().on_green())?;
+        writeln!(&mut buf, "{}", toto.black().on_white())?;
+        writeln!(&mut buf, "******")?;
+        writeln!(&mut buf, "{}", toto.green())?;
+        writeln!(&mut buf, "{}", toto.yellow())?;
+        writeln!(&mut buf, "{}", toto.purple())?;
+        writeln!(&mut buf, "{}", toto.magenta())?;
+        writeln!(&mut buf, "{}", toto.cyan())?;
+        writeln!(&mut buf, "{}", toto.white())?;
+        writeln!(&mut buf, "{}", toto.white().red().blue().green())?;
+        writeln!(&mut buf, "{}", toto.truecolor(255, 0, 0))?;
+        writeln!(&mut buf, "{}", toto.truecolor(255, 255, 0))?;
+        writeln!(&mut buf, "{}", toto.on_truecolor(0, 80, 80))?;
+        writeln!(&mut buf, "{}", toto.custom_color((255, 255, 0)))?;
+        writeln!(&mut buf, "{}", toto.on_custom_color((0, 80, 80)))?;
+        #[cfg(feature = "no-color")]
+        insta::assert_snapshot!("it_works_no_color", buf);
+        #[cfg(not(feature = "no-color"))]
+        insta::assert_snapshot!("it_works", buf);
+        Ok(())
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,7 +736,7 @@ impl From<ColoredString> for Box<dyn Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fmt::Write, error::Error};
+    use std::{error::Error, fmt::Write};
 
     #[test]
     fn formatting() {

--- a/src/snapshots/colored__customcolors__tests__main.snap
+++ b/src/snapshots/colored__customcolors__tests__main.snap
@@ -1,0 +1,5 @@
+---
+source: src/customcolors.rs
+expression: "\"Greetings from Ukraine\".custom_color(my_color)"
+---
+[38;2;0;120;120mGreetings from Ukraine[0m

--- a/src/snapshots/colored__tests__it_works.snap
+++ b/src/snapshots/colored__tests__it_works.snap
@@ -1,0 +1,41 @@
+---
+source: src/lib.rs
+expression: buf
+---
+[31mtoto[0m
+[31mtoto[0m
+[34mtoto[0m
+blue style ****
+[1mtoto[0m
+[1;31myeah ! Red bold ![0m
+[1;33myeah ! Yellow bold ![0m
+[1;34mtoto[0m
+[1;34mtoto[0m
+[1;4;34mtoto[0m
+[3;34mtoto[0m
+******
+test clearing
+red cleared
+bold cyan cleared
+******
+Bg tests
+[44;32mtoto[0m
+[45;33mtoto[0m
+[43;35mtoto[0m
+[47;35mtoto[0m
+[42;36mtoto[0m
+[47;30mtoto[0m
+******
+[32mtoto[0m
+[33mtoto[0m
+[35mtoto[0m
+[35mtoto[0m
+[36mtoto[0m
+[37mtoto[0m
+[32mtoto[0m
+[38;2;255;0;0mtoto[0m
+[38;2;255;255;0mtoto[0m
+[48;2;0;80;80mtoto[0m
+[38;2;255;255;0mtoto[0m
+[48;2;0;80;80mtoto[0m
+

--- a/src/snapshots/colored__tests__it_works_no_color.snap
+++ b/src/snapshots/colored__tests__it_works_no_color.snap
@@ -1,0 +1,41 @@
+---
+source: src/lib.rs
+expression: buf
+---
+toto
+toto
+toto
+blue style ****
+toto
+yeah ! Red bold !
+yeah ! Yellow bold !
+toto
+toto
+toto
+toto
+******
+test clearing
+red cleared
+bold cyan cleared
+******
+Bg tests
+toto
+toto
+toto
+toto
+toto
+toto
+******
+toto
+toto
+toto
+toto
+toto
+toto
+toto
+toto
+toto
+toto
+toto
+toto
+


### PR DESCRIPTION
As discussed in #156, this converts the visual tests into things that can be asserted with `cargo test`. These can still be visually reviewed with `cat path/to/snapshot`. This also registers the detected language for `*.snap` files as plain text -- currently, GitHub will detect them as *Jest* snapshot files and apply a JavaScript-like syntax highlighting otherwise. This also installs `cargo-insta` when a contributor creates a new codespace.

The one `println!` in a test that I didn't address is here
https://github.com/colored-rs/colored/blob/682adf8050f7566b4cef125515c1248c8e55736b/src/lib.rs#L839

Since that didn't look like part of the test, but just a snippet to help debug. I was tempted to switch it to a `dbg!` call, but `dbg!` prints the `Debug` formatting instead of the display formatting.