### PR TITLE
replace lazy_static with OnceLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - Implemented bitwise operators `BitAnd`, `BitOr`, `BitXor`, and `Not` which all combine `Styles`\'s and output `Style`\'s. These can also take a `Style` as an operand.
 - Added additional testing for all of the above changes.
 - Added methods `with_style` and `with_color_and_style` to `Colorize`.
+- Replaced lazy_static with `std::sync::OnceLock`. Soft breaking change by removing the global `SHOULD_COLORIZE`.
 
 # 2.1.0
 * Impl From<String> for ColoredString by @mahor1221 in https://github.com/colored-rs/colored/pull/126

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = "1.70"
 no-color = []
 
 [dependencies]
-lazy_static = "1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48"

--- a/src/control.rs
+++ b/src/control.rs
@@ -4,6 +4,7 @@ use std::default::Default;
 use std::env;
 use std::io::{self, IsTerminal};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 
 /// Sets a flag to the console to use a virtual terminal environment.
 ///
@@ -69,18 +70,19 @@ pub struct ShouldColorize {
 /// Use this to force colored to ignore the environment and always/never colorize
 /// See example/control.rs
 pub fn set_override(override_colorize: bool) {
-    SHOULD_COLORIZE.set_override(override_colorize)
+    should_colorize_global().set_override(override_colorize)
 }
 
 /// Remove the manual override and let the environment decide if it's ok to colorize
 /// See example/control.rs
 pub fn unset_override() {
-    SHOULD_COLORIZE.unset_override()
+    should_colorize_global().unset_override()
 }
 
-lazy_static! {
 /// The persistent [`ShouldColorize`].
-    pub static ref SHOULD_COLORIZE: ShouldColorize = ShouldColorize::from_env();
+pub fn should_colorize_global() -> &'static ShouldColorize {
+    static SHOULD_COLORIZE: OnceLock<ShouldColorize> = OnceLock::new();
+    SHOULD_COLORIZE.get_or_init(ShouldColorize::from_env)
 }
 
 impl Default for ShouldColorize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,6 @@
 //! modify them.
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate lazy_static;
-
 #[cfg(test)]
 extern crate rspec;
 
@@ -491,7 +488,7 @@ impl ColoredString {
 
     #[cfg(not(feature = "no-color"))]
     fn has_colors(&self) -> bool {
-        control::SHOULD_COLORIZE.should_colorize()
+        control::should_colorize_global().should_colorize()
     }
 
     #[cfg(feature = "no-color")]


### PR DESCRIPTION
Solves #163

This is technically a breaking change because `SHOULD_COLORIZE` used to be public a static var, and now it's a function.

If this is not acceptable, the other variant would be to use the `once_cell` crate which provides [Lazy](https://docs.rs/once_cell/latest/once_cell/sync/struct.Lazy.html) which is more similar to how `lazy_static` was working. This API is unstable in std at the moment.