### PR TITLE
fix usage of wildcard import

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ and add this to your `lib.rs` or `main.rs`:
 ```rust
     extern crate colored; // not needed in Rust 2018+
 
-    use colored::*;
+    use colored::Colorize;
 
     // test the example with `cargo run --example most_simple`
     fn main() {


### PR DESCRIPTION
In the following code in the readme, 
```rust
 extern crate colored; // not needed in Rust 2018+

    use colored::*;

    // test the example with `cargo run --example most_simple`
    fn main() {
        // TADAA!
        println!("{} {} !", "it".green(), "works".blue().bold());
    }
```
there is a wildcard import. Wouldn't it be better to use just colored::Colorize instead?  

Running clippy with the following flags:
`cargo clippy --workspace --all-targets --all-features -- -D warnings -
W clippy::pedantic`  
gives an error and suggests using colored::Colorize instead. I hope this pr is fine.