### PR TITLE
Removes `lazy_static` in favor of OnceLock.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ rust-version = "1.70"
 # with this feature, no color will ever be written
 no-color = []
 
-[dependencies]
-lazy_static = "1"
-
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48"
 features = [

--- a/src/control.rs
+++ b/src/control.rs
@@ -4,6 +4,7 @@ use std::default::Default;
 use std::env;
 use std::io::{self, IsTerminal};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 
 /// Sets a flag to the console to use a virtual terminal environment.
 ///
@@ -69,19 +70,19 @@ pub struct ShouldColorize {
 /// Use this to force colored to ignore the environment and always/never colorize
 /// See example/control.rs
 pub fn set_override(override_colorize: bool) {
-    SHOULD_COLORIZE.set_override(override_colorize)
+    let colorize = SHOULD_COLORIZE.get_or_init(ShouldColorize::from_env);
+    colorize.set_override(override_colorize)
 }
 
 /// Remove the manual override and let the environment decide if it's ok to colorize
 /// See example/control.rs
 pub fn unset_override() {
-    SHOULD_COLORIZE.unset_override()
+    let colorize = SHOULD_COLORIZE.get_or_init(ShouldColorize::from_env);
+    colorize.unset_override()
 }
 
-lazy_static! {
 /// The persistent [`ShouldColorize`].
-    pub static ref SHOULD_COLORIZE: ShouldColorize = ShouldColorize::from_env();
-}
+pub static SHOULD_COLORIZE: OnceLock<ShouldColorize> = OnceLock::new();
 
 impl Default for ShouldColorize {
     fn default() -> ShouldColorize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,6 @@
 //! modify them.
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate lazy_static;
-
 #[cfg(test)]
 extern crate rspec;
 
@@ -491,7 +488,10 @@ impl ColoredString {
 
     #[cfg(not(feature = "no-color"))]
     fn has_colors(&self) -> bool {
-        control::SHOULD_COLORIZE.should_colorize()
+        use control::SHOULD_COLORIZE;
+
+        let colorize = SHOULD_COLORIZE.get_or_init(control::ShouldColorize::from_env);
+        colorize.should_colorize()
     }
 
     #[cfg(feature = "no-color")]


### PR DESCRIPTION
The goal here was simply to remove `lazy_static` in favor of the the standard lib functions that replaced it. This is the smallest number of code changes that I could create to make that happen. I have tested this in my own project and it works as it did before.