### PR TITLE
Remove unnecessary lazy_static dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu", "windows", "macos"]
-        version: ["stable", "beta", "1.70"]
+        version: ["stable", "beta", "1.80"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -59,4 +59,3 @@ jobs:
         uses: actions/checkout@v3
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 3.0.0
+- **[BREAKING CHANGE]:** Upgrade MSRV to 1.80 and remove the then unnecessary lazy_static dependency.
+
 # 2.2.0
 - Updated top-level docs to include a note about `ColoredString`\'s role in the `Colorize` pipeline as well as link to it to suggest learning more about how to manipulate existing `ColoredString`\'s.
 - Changes to `ColoredString`:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,12 @@ homepage = "https://github.com/mackwic/colored"
 repository = "https://github.com/mackwic/colored"
 readme = "README.md"
 keywords = ["color", "string", "term", "ansi_term", "term-painter"]
-rust-version = "1.70"
+rust-version = "1.80"
 
 [features]
 # with this feature, no color will ever be written
 no-color = []
 
-[dependencies]
-lazy_static = "1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "colored"
 description = "The most simple way to add colors in your terminal"
-version = "2.1.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["Thomas Wickham <mackwic@gmail.com>"]
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ providing a reference implementation, which greatly helped making this crate
 output correct strings.
 
 ## Minimum Supported Rust Version (MSRV)
-The current MSRV is `1.70`, which is checked and enforced automatically via CI. This version may change in the future in minor version bumps, so if you require a specific Rust version you should use a restricted version requirement such as `~X.Y`.
+The current MSRV is `1.80`, which is checked and enforced automatically via CI. This version may change in the future in minor version bumps, so if you require a specific Rust version you should use a restricted version requirement such as `~X.Y`.
 
 ## License
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -4,6 +4,7 @@ use std::default::Default;
 use std::env;
 use std::io::{self, IsTerminal};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::LazyLock;
 
 /// Sets a flag to the console to use a virtual terminal environment.
 ///
@@ -78,10 +79,8 @@ pub fn unset_override() {
     SHOULD_COLORIZE.unset_override()
 }
 
-lazy_static! {
 /// The persistent [`ShouldColorize`].
-    pub static ref SHOULD_COLORIZE: ShouldColorize = ShouldColorize::from_env();
-}
+pub static SHOULD_COLORIZE: LazyLock<ShouldColorize> = LazyLock::new(ShouldColorize::from_env);
 
 impl Default for ShouldColorize {
     fn default() -> ShouldColorize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,6 @@
 //! modify them.
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate lazy_static;
-
 #[cfg(test)]
 extern crate rspec;
 


### PR DESCRIPTION
Note that this PR upgrades the MSRV to 1.80

Resolves #175
Closes #119
Closes #170