### PR TITLE
Update dev-dependency rspec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ features = [
 [dev_dependencies]
 ansi_term = "0.12"
 insta = "1"
-rspec = "=1.0.0-beta.3"
+rspec = "1"

--- a/src/control.rs
+++ b/src/control.rs
@@ -163,18 +163,13 @@ impl ShouldColorize {
 mod specs {
     use super::*;
     use rspec;
-    use rspec::context::*;
     use std::env;
 
     #[test]
     fn clicolor_behavior() {
-        use std::io;
-
-        let stdout = &mut io::stdout();
-        let mut formatter = rspec::formatter::Simple::new(stdout);
-        let mut runner = describe("ShouldColorize", |ctx| {
-            ctx.describe("::normalize_env", |ctx| {
-                ctx.it("should return None if error", || {
+        rspec::run(&rspec::describe("ShouldColorize", (), |ctx| {
+            ctx.specify("::normalize_env", |ctx| {
+                ctx.it("should return None if error", |_| {
                     assert_eq!(
                         None,
                         ShouldColorize::normalize_env(Err(env::VarError::NotPresent))
@@ -185,19 +180,19 @@ mod specs {
                     )
                 });
 
-                ctx.it("should return Some(true) if != 0", || {
+                ctx.it("should return Some(true) if != 0", |_| {
                     Some(true) == ShouldColorize::normalize_env(Ok(String::from("1")))
                 });
 
-                ctx.it("should return Some(false) if == 0", || {
+                ctx.it("should return Some(false) if == 0", |_| {
                     Some(false) == ShouldColorize::normalize_env(Ok(String::from("0")))
                 });
             });
 
-            ctx.describe("::resolve_clicolor_force", |ctx| {
+            ctx.specify("::resolve_clicolor_force", |ctx| {
                 ctx.it(
                     "should return None if NO_COLOR is not set and CLICOLOR_FORCE is not set or set to 0",
-                    || {
+                    |_| {
                         assert_eq!(
                             None,
                             ShouldColorize::resolve_clicolor_force(
@@ -217,7 +212,7 @@ mod specs {
 
                 ctx.it(
                     "should return Some(false) if NO_COLOR is set and CLICOLOR_FORCE is not enabled",
-                    || {
+                    |_| {
                         assert_eq!(
                             Some(false),
                             ShouldColorize::resolve_clicolor_force(
@@ -244,7 +239,7 @@ mod specs {
 
                 ctx.it(
                     "should prioritize CLICOLOR_FORCE over NO_COLOR if CLICOLOR_FORCE is set to non-zero value",
-                    || {
+                    |_| {
                         assert_eq!(
                             Some(true),
                             ShouldColorize::resolve_clicolor_force(
@@ -270,18 +265,18 @@ mod specs {
                 );
             });
 
-            ctx.describe("constructors", |ctx| {
-                ctx.it("should have a default constructor", || {
+            ctx.specify("constructors", |ctx| {
+                ctx.it("should have a default constructor", |_| {
                     ShouldColorize::default();
                 });
 
-                ctx.it("should have an environment constructor", || {
+                ctx.it("should have an environment constructor", |_| {
                     ShouldColorize::from_env();
                 });
             });
 
-            ctx.describe("when only changing clicolors", |ctx| {
-                ctx.it("clicolor == false means no colors", || {
+            ctx.specify("when only changing clicolors", |ctx| {
+                ctx.it("clicolor == false means no colors", |_| {
                     let colorize_control = ShouldColorize {
                         clicolor: false,
                         ..ShouldColorize::default()
@@ -289,7 +284,7 @@ mod specs {
                     false == colorize_control.should_colorize()
                 });
 
-                ctx.it("clicolor == true means colors !", || {
+                ctx.it("clicolor == true means colors !", |_| {
                     let colorize_control = ShouldColorize {
                         clicolor: true,
                         ..ShouldColorize::default()
@@ -297,15 +292,15 @@ mod specs {
                     true == colorize_control.should_colorize()
                 });
 
-                ctx.it("unset clicolors implies true", || {
+                ctx.it("unset clicolors implies true", |_| {
                     true == ShouldColorize::default().should_colorize()
                 });
             });
 
-            ctx.describe("when using clicolor_force", |ctx| {
+            ctx.specify("when using clicolor_force", |ctx| {
                 ctx.it(
                     "clicolor_force should force to true no matter clicolor",
-                    || {
+                    |_| {
                         let colorize_control = ShouldColorize {
                             clicolor: false,
                             clicolor_force: Some(true),
@@ -318,7 +313,7 @@ mod specs {
 
                 ctx.it(
                     "clicolor_force should force to false no matter clicolor",
-                    || {
+                    |_| {
                         let colorize_control = ShouldColorize {
                             clicolor: true,
                             clicolor_force: Some(false),
@@ -330,8 +325,8 @@ mod specs {
                 );
             });
 
-            ctx.describe("using a manual override", |ctx| {
-                ctx.it("shoud colorize if manual_override is true, but clicolor is false and clicolor_force also false", || {
+            ctx.specify("using a manual override", |ctx| {
+                ctx.it("shoud colorize if manual_override is true, but clicolor is false and clicolor_force also false", |_| {
                     let colorize_control = ShouldColorize {
                         clicolor: false,
                         clicolor_force: None,
@@ -343,7 +338,7 @@ mod specs {
                     true == colorize_control.should_colorize()
                 });
 
-                ctx.it("should not colorize if manual_override is false, but clicolor is true or clicolor_force is true", || {
+                ctx.it("should not colorize if manual_override is false, but clicolor is true or clicolor_force is true", |_| {
                     let colorize_control = ShouldColorize {
                         clicolor: true,
                         clicolor_force: Some(true),
@@ -356,13 +351,13 @@ mod specs {
                 })
             });
 
-            ctx.describe("::set_override", |ctx| {
-                ctx.it("should exists", || {
+            ctx.specify("::set_override", |ctx| {
+                ctx.it("should exists", |_| {
                     let colorize_control = ShouldColorize::default();
                     colorize_control.set_override(true);
                 });
 
-                ctx.it("set the manual_override property", || {
+                ctx.it("set the manual_override property", |_| {
                     let colorize_control = ShouldColorize::default();
                     colorize_control.set_override(true);
                     {
@@ -385,13 +380,13 @@ mod specs {
                 });
             });
 
-            ctx.describe("::unset_override", |ctx| {
-                ctx.it("should exists", || {
+            ctx.specify("::unset_override", |ctx| {
+                ctx.it("should exists", |_| {
                     let colorize_control = ShouldColorize::default();
                     colorize_control.unset_override();
                 });
 
-                ctx.it("unset the manual_override property", || {
+                ctx.it("unset the manual_override property", |_| {
                     let colorize_control = ShouldColorize::default();
                     colorize_control.set_override(true);
                     colorize_control.unset_override();
@@ -401,8 +396,6 @@ mod specs {
                     );
                 });
             });
-        });
-        runner.add_event_handler(&mut formatter);
-        runner.run().unwrap();
+        }));
     }
 }


### PR DESCRIPTION
While looking at the crate version I noticed this one is finally released (3 years ago), so figured I could bump this too. I kept the same format as the other dev dependencies for consistency.