### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Inspired by discussion in https://github.com/colored-rs/colored/pull/177, this will configure GitHub to automatically update dependencies, as long as dependabot is enabled in the repository settings. IIRC this is the default when a `dependabot.yml` file is added to a non-fork repository.

This is the bare minimum configuration, but there are some additional options. One that might be appealing is the ability to group packages together in one PR (e.g. group all dev dependencies). As it is it makes a PR for each dependency that gets updated.

Because this repository doesn't get frequent traffic, I decided to make updates monthly.
