### PR TITLE
Clippy lints, fix deprecation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ features = [
     "Win32_System_Console",
 ]
 
-[dev_dependencies]
+[dev-dependencies]
 ansi_term = "0.12"
 insta = "1"
 rspec = "1"

--- a/examples/control.rs
+++ b/examples/control.rs
@@ -4,7 +4,7 @@ use colored::*;
 
 #[cfg(not(windows))]
 fn main() {
-    both()
+    both();
 }
 
 #[cfg(windows)]

--- a/src/color.rs
+++ b/src/color.rs
@@ -85,11 +85,11 @@ impl Color {
     }
 
     /// Gets the closest plain color to the TrueColor
-    fn closest_color_euclidean(&self) -> Self {
+    fn closest_color_euclidean(self) -> Self {
         use std::cmp;
         use Color::*;
 
-        match *self {
+        match self {
             TrueColor {
                 r: r1,
                 g: g1,
@@ -332,13 +332,13 @@ mod tests {
         #[test]
         fn parse() {
             let color: Result<Color, _> = "blue".parse();
-            assert_eq!(Ok(Color::Blue), color)
+            assert_eq!(Ok(Color::Blue), color);
         }
 
         #[test]
         fn error() {
             let color: Result<Color, ()> = "bloublou".parse();
-            assert_eq!(Err(()), color)
+            assert_eq!(Err(()), color);
         }
     }
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -69,13 +69,13 @@ pub struct ShouldColorize {
 /// Use this to force colored to ignore the environment and always/never colorize
 /// See example/control.rs
 pub fn set_override(override_colorize: bool) {
-    SHOULD_COLORIZE.set_override(override_colorize)
+    SHOULD_COLORIZE.set_override(override_colorize);
 }
 
 /// Remove the manual override and let the environment decide if it's ok to colorize
 /// See example/control.rs
 pub fn unset_override() {
-    SHOULD_COLORIZE.unset_override()
+    SHOULD_COLORIZE.unset_override();
 }
 
 lazy_static! {
@@ -177,7 +177,7 @@ mod specs {
                     assert_eq!(
                         None,
                         ShouldColorize::normalize_env(Err(env::VarError::NotUnicode("".into())))
-                    )
+                    );
                 });
 
                 ctx.it("should return Some(true) if != 0", |_| {
@@ -281,7 +281,7 @@ mod specs {
                         clicolor: false,
                         ..ShouldColorize::default()
                     };
-                    false == colorize_control.should_colorize()
+                    !colorize_control.should_colorize()
                 });
 
                 ctx.it("clicolor == true means colors !", |_| {
@@ -289,11 +289,11 @@ mod specs {
                         clicolor: true,
                         ..ShouldColorize::default()
                     };
-                    true == colorize_control.should_colorize()
+                    colorize_control.should_colorize()
                 });
 
                 ctx.it("unset clicolors implies true", |_| {
-                    true == ShouldColorize::default().should_colorize()
+                    ShouldColorize::default().should_colorize()
                 });
             });
 
@@ -307,7 +307,7 @@ mod specs {
                             ..ShouldColorize::default()
                         };
 
-                        true == colorize_control.should_colorize()
+                        colorize_control.should_colorize()
                     },
                 );
 
@@ -320,7 +320,7 @@ mod specs {
                             ..ShouldColorize::default()
                         };
 
-                        false == colorize_control.should_colorize()
+                        !colorize_control.should_colorize()
                     },
                 );
             });
@@ -332,10 +332,9 @@ mod specs {
                         clicolor_force: None,
                         has_manual_override: AtomicBool::new(true),
                         manual_override: AtomicBool::new(true),
-                        .. ShouldColorize::default()
                     };
 
-                    true == colorize_control.should_colorize()
+                    colorize_control.should_colorize();
                 });
 
                 ctx.it("should not colorize if manual_override is false, but clicolor is true or clicolor_force is true", |_| {
@@ -344,11 +343,10 @@ mod specs {
                         clicolor_force: Some(true),
                         has_manual_override: AtomicBool::new(true),
                         manual_override: AtomicBool::new(false),
-                        .. ShouldColorize::default()
                     };
 
-                    false == colorize_control.should_colorize()
-                })
+                    !colorize_control.should_colorize()
+                });
             });
 
             ctx.specify("::set_override", |ctx| {
@@ -361,21 +359,15 @@ mod specs {
                     let colorize_control = ShouldColorize::default();
                     colorize_control.set_override(true);
                     {
-                        assert_eq!(
-                            true,
-                            colorize_control.has_manual_override.load(Ordering::Relaxed)
-                        );
+                        assert!(colorize_control.has_manual_override.load(Ordering::Relaxed));
                         let val = colorize_control.manual_override.load(Ordering::Relaxed);
-                        assert_eq!(true, val);
+                        assert!(val);
                     }
                     colorize_control.set_override(false);
                     {
-                        assert_eq!(
-                            true,
-                            colorize_control.has_manual_override.load(Ordering::Relaxed)
-                        );
+                        assert!(colorize_control.has_manual_override.load(Ordering::Relaxed));
                         let val = colorize_control.manual_override.load(Ordering::Relaxed);
-                        assert_eq!(false, val);
+                        assert!(!val);
                     }
                 });
             });
@@ -390,10 +382,7 @@ mod specs {
                     let colorize_control = ShouldColorize::default();
                     colorize_control.set_override(true);
                     colorize_control.unset_override();
-                    assert_eq!(
-                        false,
-                        colorize_control.has_manual_override.load(Ordering::Relaxed)
-                    );
+                    assert!(!colorize_control.has_manual_override.load(Ordering::Relaxed));
                 });
             });
         }));

--- a/src/customcolors.rs
+++ b/src/customcolors.rs
@@ -30,7 +30,7 @@ mod tests {
     #[test]
     fn main() {
         let my_color = CustomColor::new(0, 120, 120);
-        insta::assert_display_snapshot!("Greetings from Ukraine".custom_color(my_color));
+        insta::assert_snapshot!("Greetings from Ukraine".custom_color(my_color));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,17 +490,17 @@ impl ColoredString {
     }
 
     #[cfg(not(feature = "no-color"))]
-    fn has_colors(&self) -> bool {
+    fn has_colors() -> bool {
         control::SHOULD_COLORIZE.should_colorize()
     }
 
     #[cfg(feature = "no-color")]
-    fn has_colors(&self) -> bool {
+    fn has_colors() -> bool {
         false
     }
 
     fn compute_style(&self) -> String {
-        if !self.has_colors() || self.is_plain() {
+        if !ColoredString::has_colors() || self.is_plain() {
             return String::new();
         }
 
@@ -534,7 +534,7 @@ impl ColoredString {
     }
 
     fn escape_inner_reset_sequences(&self) -> Cow<str> {
-        if !self.has_colors() || self.is_plain() {
+        if !ColoredString::has_colors() || self.is_plain() {
             return self.input.as_str().into();
         }
 
@@ -713,7 +713,7 @@ impl<'a> Colorize for &'a str {
 
 impl fmt::Display for ColoredString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if !self.has_colors() || self.is_plain() {
+        if !ColoredString::has_colors() || self.is_plain() {
             return <String as fmt::Display>::fmt(&self.input, f);
         }
 
@@ -944,22 +944,22 @@ mod tests {
 
     #[test]
     fn color_fn() {
-        assert_eq!("blue".blue(), "blue".color("blue"))
+        assert_eq!("blue".blue(), "blue".color("blue"));
     }
 
     #[test]
     fn on_color_fn() {
-        assert_eq!("blue".on_blue(), "blue".on_color("blue"))
+        assert_eq!("blue".on_blue(), "blue".on_color("blue"));
     }
 
     #[test]
     fn bright_color_fn() {
-        assert_eq!("blue".bright_blue(), "blue".color("bright blue"))
+        assert_eq!("blue".bright_blue(), "blue".color("bright blue"));
     }
 
     #[test]
     fn on_bright_color_fn() {
-        assert_eq!("blue".on_bright_blue(), "blue".on_color("bright blue"))
+        assert_eq!("blue".on_bright_blue(), "blue".on_color("bright blue"));
     }
 
     #[test]
@@ -981,8 +981,8 @@ mod tests {
         let cstring = cstring.bold().italic();
         assert_eq!(cstring.fgcolor(), Some(Color::Blue));
         assert_eq!(cstring.bgcolor(), Some(Color::BrightYellow));
-        assert_eq!(cstring.style().contains(Styles::Bold), true);
-        assert_eq!(cstring.style().contains(Styles::Italic), true);
-        assert_eq!(cstring.style().contains(Styles::Dimmed), false);
+        assert!(cstring.style().contains(Styles::Bold));
+        assert!(cstring.style().contains(Styles::Italic));
+        assert!(!cstring.style().contains(Styles::Dimmed));
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -563,7 +563,7 @@ mod tests {
 
         #[test]
         fn empty_is_none() {
-            assert_eq!(None, Styles::from_u8(CLEARV))
+            assert_eq!(None, Styles::from_u8(CLEARV));
         }
     }
 
@@ -632,19 +632,19 @@ mod tests {
         #[test]
         fn aggreg1() {
             let styles: &[Styles] = &[Bold, Bold, Bold];
-            test_aggreg!(styles, [Bold])
+            test_aggreg!(styles, [Bold]);
         }
 
         #[test]
         fn aggreg2() {
             let styles: &[Styles] = &[Italic, Italic, Bold, Bold];
-            test_aggreg!(styles, [Bold, Italic])
+            test_aggreg!(styles, [Bold, Italic]);
         }
 
         #[test]
         fn aggreg3() {
             let styles: &[Styles] = &[Bold, Italic, Bold];
-            test_aggreg!(styles, [Bold, Italic])
+            test_aggreg!(styles, [Bold, Italic]);
         }
 
         macro_rules! test_combine {
@@ -658,49 +658,49 @@ mod tests {
         #[test]
         fn two1() {
             let s: &[Styles] = &[Bold, Underline];
-            test_combine!(s)
+            test_combine!(s);
         }
 
         #[test]
         fn two2() {
             let s: &[Styles] = &[Underline, Italic];
-            test_combine!(s)
+            test_combine!(s);
         }
 
         #[test]
         fn two3() {
             let s: &[Styles] = &[Bold, Italic];
-            test_combine!(s)
+            test_combine!(s);
         }
 
         #[test]
         fn three1() {
             let s: &[Styles] = &[Bold, Underline, Italic];
-            test_combine!(s)
+            test_combine!(s);
         }
 
         #[test]
         fn three2() {
             let s: &[Styles] = &[Dimmed, Underline, Italic];
-            test_combine!(s)
+            test_combine!(s);
         }
 
         #[test]
         fn four() {
             let s: &[Styles] = &[Dimmed, Underline, Italic, Hidden];
-            test_combine!(s)
+            test_combine!(s);
         }
 
         #[test]
         fn five() {
             let s: &[Styles] = &[Dimmed, Underline, Italic, Blink, Hidden];
-            test_combine!(s)
+            test_combine!(s);
         }
 
         #[test]
         fn six() {
             let s: &[Styles] = &[Bold, Dimmed, Underline, Italic, Blink, Hidden];
-            test_combine!(s)
+            test_combine!(s);
         }
 
         #[test]
@@ -715,7 +715,7 @@ mod tests {
                 Hidden,
                 Strikethrough,
             ];
-            test_combine!(s)
+            test_combine!(s);
         }
     }
 
@@ -724,9 +724,9 @@ mod tests {
         let mut style = Style(Styles::Bold.to_u8());
         style.add(Styles::Italic);
 
-        assert_eq!(style.contains(Styles::Bold), true);
-        assert_eq!(style.contains(Styles::Italic), true);
-        assert_eq!(style.contains(Styles::Dimmed), false);
+        assert!(style.contains(Styles::Bold));
+        assert!(style.contains(Styles::Italic));
+        assert!(!style.contains(Styles::Dimmed));
     }
 
     mod style_bitwise_logic {

--- a/tests/ansi_term_compat.rs
+++ b/tests/ansi_term_compat.rs
@@ -35,13 +35,16 @@ mod compat_colors {
 }
 
 macro_rules! test_simple_style {
-    ($string:expr, $style:ident) => {
+    ($string:expr, $colored_style:ident, $ansi_term_style:ident) => {
         #[test]
-        fn $style() {
-            let s = format!("{} {}", $string, stringify!($style));
+        fn $colored_style() {
+            let s = format!("{} {}", $string, stringify!($colored_style));
             assert_eq!(
-                s.$style().to_string(),
-                ansi_term::Style::new().$style().paint(s).to_string()
+                s.$colored_style().to_string(),
+                ansi_term::Style::new()
+                    .$ansi_term_style()
+                    .paint(s)
+                    .to_string()
             )
         }
     };
@@ -53,13 +56,13 @@ mod compat_styles {
     use super::colored;
     use super::colored::*;
 
-    test_simple_style!("test string", bold);
-    test_simple_style!("test string", dimmed);
-    test_simple_style!("test string", italic);
-    test_simple_style!("test string", underline);
-    test_simple_style!("test string", blink);
-    test_simple_style!("test string", reverse);
-    test_simple_style!("test string", hidden);
+    test_simple_style!("test string", bold, bold);
+    test_simple_style!("test string", dimmed, dimmed);
+    test_simple_style!("test string", italic, italic);
+    test_simple_style!("test string", underline, underline);
+    test_simple_style!("test string", blink, blink);
+    test_simple_style!("test string", reversed, reverse);
+    test_simple_style!("test string", hidden, hidden);
 }
 
 macro_rules! test_simple_bgcolor {


### PR DESCRIPTION
Went ahead and fixed some clippy lints and deprecation warnings. Might break backwards compatibility, so maybe merge this before bumping the version to 3.0