### PR TITLE
cargo: supported range for windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ no-color = []
 lazy_static = "1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48"
+version = ">=0.48,<=0.59"
 features = [
     "Win32_Foundation",
     "Win32_System_Console",


### PR DESCRIPTION
this will allow downstream users to choose windows-sys version as per their compatibility