### PR TITLE
chore: replace lazy_static with once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ no-color = []
 
 [dependencies]
 lazy_static = "1"
+once_cell = "1.20.2"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = ">=0.48,<=0.59"

--- a/src/control.rs
+++ b/src/control.rs
@@ -5,6 +5,8 @@ use std::env;
 use std::io::{self, IsTerminal};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use once_cell::sync::Lazy;
+
 /// Sets a flag to the console to use a virtual terminal environment.
 ///
 /// This is primarily used for Windows 10 environments which will not correctly colorize
@@ -78,10 +80,8 @@ pub fn unset_override() {
     SHOULD_COLORIZE.unset_override();
 }
 
-lazy_static! {
 /// The persistent [`ShouldColorize`].
-    pub static ref SHOULD_COLORIZE: ShouldColorize = ShouldColorize::from_env();
-}
+pub static SHOULD_COLORIZE: Lazy<ShouldColorize> = Lazy::new(ShouldColorize::from_env);
 
 impl Default for ShouldColorize {
     fn default() -> ShouldColorize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,6 @@
 //! modify them.
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate lazy_static;
-
 #[cfg(test)]
 extern crate rspec;
 


### PR DESCRIPTION
lazy_static is slower to compile.

Once we bump MSRV to 1.80, we can use std's LazyLock instead then.