### PR TITLE
Add hex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Coloring terminal so simple, you already know how to do it!
     "purple and magenta are the same".purple().magenta();
     "and so are normal and clear".normal().clear();
     "you can specify color by string".color("blue").on_color("red");
+    "you can also use hex colors".color("#0057B7").on_color("#fd0");
     String::from("this also works!").green().bold();
     format!("{:30}", "format works as expected. This will be padded".blue());
     format!("{:.3}", "and this will be green but truncated to 3 chars".green());

--- a/src/color.rs
+++ b/src/color.rs
@@ -237,7 +237,6 @@ impl FromStr for Color {
     }
 }
 
-#[inline(always)]
 fn hex_char(c: char) -> Option<u8> {
     match c {
         '0'..='9' => Some(c as u8 - 48),
@@ -272,7 +271,7 @@ fn parse_hex(s: &str) -> Option<Color> {
     let c5 = chars.next()?;
     let c6 = chars.next()?;
 
-    if chars.next() != None {
+    if chars.next().is_some() {
         return None;
     }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -231,8 +231,41 @@ impl FromStr for Color {
             "bright magenta" => Ok(Self::BrightMagenta),
             "bright cyan" => Ok(Self::BrightCyan),
             "bright white" => Ok(Self::BrightWhite),
+            s if s.starts_with('#') => parse_hex(s),
             _ => Err(()),
         }
+    }
+}
+
+#[inline(always)]
+fn hex_char(d: char) -> Result<u8, ()> {
+    match d {
+        '0'..='9' => Ok(d as u8 - 48),
+        'a'..='f' => Ok(d as u8 - 87),
+        'A'..='F' => Ok(d as u8 - 55),
+        _ => Err(()),
+    }
+}
+
+fn hex_pair(d1: char, d2: char) -> Result<u8, ()> {
+    Ok(hex_char(d1)? * 16 + hex_char(d2)?)
+}
+
+fn parse_hex(s: &str) -> Result<Color, ()> {
+    let chars: Vec<_> = s.chars().collect();
+
+    match chars.as_slice() {
+        &['#', r, g, b] => Ok(Color::TrueColor {
+            r: hex_pair(r, r)?,
+            g: hex_pair(g, g)?,
+            b: hex_pair(b, b)?,
+        }),
+        &['#', r1, r2, g1, g2, b1, b2] => Ok(Color::TrueColor {
+            r: hex_pair(r1, r2)?,
+            g: hex_pair(g1, g2)?,
+            b: hex_pair(b1, b2)?,
+        }),
+        _ => Err(()),
     }
 }
 
@@ -277,7 +310,14 @@ mod tests {
 
             invalid: "invalid" => Color::White,
             capitalized: "BLUE" => Color::Blue,
-            mixed_case: "bLuE" => Color::Blue
+            mixed_case: "bLuE" => Color::Blue,
+
+            hex3_lower: "#abc" => Color::TrueColor { r: 170, g: 187, b: 204 },
+            hex3_upper: "#ABC" => Color::TrueColor { r: 170, g: 187, b: 204 },
+            hex3_mixed: "#aBc" => Color::TrueColor { r: 170, g: 187, b: 204 },
+            hex6_lower: "#abcdef" => Color::TrueColor { r: 171, g: 205, b: 239 },
+            hex6_upper: "#ABCDEF" => Color::TrueColor { r: 171, g: 205, b: 239 },
+            hex6_mixed: "#aBcDeF" => Color::TrueColor { r: 171, g: 205, b: 239 }
         );
     }
 
@@ -318,7 +358,14 @@ mod tests {
 
             invalid: "invalid" => Color::White,
             capitalized: "BLUE" => Color::Blue,
-            mixed_case: "bLuE" => Color::Blue
+            mixed_case: "bLuE" => Color::Blue,
+
+            hex3_lower: "#abc" => Color::TrueColor { r: 170, g: 187, b: 204 },
+            hex3_upper: "#ABC" => Color::TrueColor { r: 170, g: 187, b: 204 },
+            hex3_mixed: "#aBc" => Color::TrueColor { r: 170, g: 187, b: 204 },
+            hex6_lower: "#abcdef" => Color::TrueColor { r: 171, g: 205, b: 239 },
+            hex6_upper: "#ABCDEF" => Color::TrueColor { r: 171, g: 205, b: 239 },
+            hex6_mixed: "#aBcDeF" => Color::TrueColor { r: 171, g: 205, b: 239 }
         );
     }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -317,7 +317,8 @@ mod tests {
             hex3_mixed: "#aBc" => Color::TrueColor { r: 170, g: 187, b: 204 },
             hex6_lower: "#abcdef" => Color::TrueColor { r: 171, g: 205, b: 239 },
             hex6_upper: "#ABCDEF" => Color::TrueColor { r: 171, g: 205, b: 239 },
-            hex6_mixed: "#aBcDeF" => Color::TrueColor { r: 171, g: 205, b: 239 }
+            hex6_mixed: "#aBcDeF" => Color::TrueColor { r: 171, g: 205, b: 239 },
+            hex_invalid: "#aa" => Color::White
         );
     }
 
@@ -365,7 +366,8 @@ mod tests {
             hex3_mixed: "#aBc" => Color::TrueColor { r: 170, g: 187, b: 204 },
             hex6_lower: "#abcdef" => Color::TrueColor { r: 171, g: 205, b: 239 },
             hex6_upper: "#ABCDEF" => Color::TrueColor { r: 171, g: 205, b: 239 },
-            hex6_mixed: "#aBcDeF" => Color::TrueColor { r: 171, g: 205, b: 239 }
+            hex6_mixed: "#aBcDeF" => Color::TrueColor { r: 171, g: 205, b: 239 },
+            hex_invalid: "#aa" => Color::White
         );
     }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -231,28 +231,24 @@ impl FromStr for Color {
             "bright magenta" => Ok(Self::BrightMagenta),
             "bright cyan" => Ok(Self::BrightCyan),
             "bright white" => Ok(Self::BrightWhite),
-            s if s.starts_with('#') => parse_hex(s).ok_or(()),
+            s if s.starts_with('#') => parse_hex(&s[1..]).ok_or(()),
             _ => Err(()),
         }
     }
 }
 
 fn parse_hex(s: &str) -> Option<Color> {
-    if s.get(..1)? != "#" {
-        return None;
-    }
-
-    if s.len() == 7 {
-        let r = u8::from_str_radix(s.get(1..3)?, 16).ok()?;
-        let g = u8::from_str_radix(s.get(3..5)?, 16).ok()?;
-        let b = u8::from_str_radix(s.get(5..7)?, 16).ok()?;
+    if s.len() == 6 {
+        let r = u8::from_str_radix(&s[0..2], 16).ok()?;
+        let g = u8::from_str_radix(&s[2..4], 16).ok()?;
+        let b = u8::from_str_radix(&s[4..6], 16).ok()?;
         Some(Color::TrueColor { r, g, b })
-    } else if s.len() == 4 {
-        let r = u8::from_str_radix(s.get(1..2)?, 16).ok()?;
+    } else if s.len() == 3 {
+        let r = u8::from_str_radix(&s[0..1], 16).ok()?;
         let r = r | (r << 4);
-        let g = u8::from_str_radix(s.get(2..3)?, 16).ok()?;
+        let g = u8::from_str_radix(&s[1..2], 16).ok()?;
         let g = g | (g << 4);
-        let b = u8::from_str_radix(s.get(3..4)?, 16).ok()?;
+        let b = u8::from_str_radix(&s[2..3], 16).ok()?;
         let b = b | (b << 4);
         Some(Color::TrueColor { r, g, b })
     } else {

--- a/src/color.rs
+++ b/src/color.rs
@@ -238,7 +238,7 @@ impl FromStr for Color {
 }
 
 fn parse_hex(s: &str) -> Option<Color> {
-    if s.get(0..1)? != "#" {
+    if s.get(..1)? != "#" {
         return None;
     }
 


### PR DESCRIPTION
Add support for hex strings (`"#abc"` or `"#abcdef"`) in place of color names when using `.color(...)`. For example

```
"this will be pink".color("#efabea")
```

The case of the hex string is ignored. If an invalid hex string is passed (including missing `#`), the color defaults to white.