### PR TITLE
README: use the latest v3.0 version for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-colored = "2"
+colored = "3"
 ```
 
 and add this to your `lib.rs` or `main.rs`:


### PR DESCRIPTION
Update the how-to-use example to use `colored = "3"` in the example toml file.