### PR TITLE
Replace 'ansi_term' dev-dependency with 'ansiterm'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 homepage = "https://github.com/mackwic/colored"
 repository = "https://github.com/mackwic/colored"
 readme = "README.md"
-keywords = ["color", "string", "term", "ansi_term", "term-painter"]
+keywords = ["color", "string", "term", "ansiterm", "ansi_term", "term-painter"]
 rust-version = "1.80"
 
 [features]
@@ -21,7 +21,7 @@ version = ">=0.48,<=0.60"
 features = ["Win32_Foundation", "Win32_System_Console"]
 
 [dev-dependencies]
-ansi_term = "0.12"
+ansiterm = "0.12"
 insta = "1"
 rspec = "1"
 

--- a/tests/ansi_term_compat.rs
+++ b/tests/ansi_term_compat.rs
@@ -1,27 +1,27 @@
 #![cfg(not(feature = "no-color"))]
 #![allow(unused_imports)]
 
-extern crate ansi_term;
+extern crate ansiterm;
 extern crate colored;
 
-use ansi_term::*;
+use ansiterm::*;
 use colored::*;
 
 macro_rules! test_simple_color {
-    ($string:expr, $colored_name:ident, $ansi_term_name:ident) => {
+    ($string:expr, $colored_name:ident, $ansiterm_name:ident) => {
         #[test]
         fn $colored_name() {
             let s = format!("{} {}", $string, stringify!($colored_name));
             assert_eq!(
                 s.$colored_name().to_string(),
-                Colour::$ansi_term_name.paint(s).to_string()
+                Colour::$ansiterm_name.paint(s).to_string()
             )
         }
     };
 }
 
 mod compat_colors {
-    use super::ansi_term::*;
+    use super::ansiterm::*;
     use super::colored::*;
 
     test_simple_color!("test string", black, Black);
@@ -35,14 +35,14 @@ mod compat_colors {
 }
 
 macro_rules! test_simple_style {
-    ($string:expr, $colored_style:ident, $ansi_term_style:ident) => {
+    ($string:expr, $colored_style:ident, $ansiterm_style:ident) => {
         #[test]
         fn $colored_style() {
             let s = format!("{} {}", $string, stringify!($colored_style));
             assert_eq!(
                 s.$colored_style().to_string(),
-                ansi_term::Style::new()
-                    .$ansi_term_style()
+                ansiterm::Style::new()
+                    .$ansiterm_style()
                     .paint(s)
                     .to_string()
             )
@@ -51,8 +51,8 @@ macro_rules! test_simple_style {
 }
 
 mod compat_styles {
-    use super::ansi_term;
-    use super::ansi_term::*;
+    use super::ansiterm;
+    use super::ansiterm::*;
     use super::colored;
     use super::colored::*;
 
@@ -66,14 +66,14 @@ mod compat_styles {
 }
 
 macro_rules! test_simple_bgcolor {
-    ($string:expr, $colored_name:ident, $ansi_term_name:ident) => {
+    ($string:expr, $colored_name:ident, $ansiterm_name:ident) => {
         #[test]
         fn $colored_name() {
             let s = format!("{} {}", $string, stringify!($colored_name));
             assert_eq!(
                 s.$colored_name().to_string(),
-                ansi_term::Style::default()
-                    .on(ansi_term::Colour::$ansi_term_name)
+                ansiterm::Style::default()
+                    .on(ansiterm::Colour::$ansiterm_name)
                     .paint(s)
                     .to_string()
             )
@@ -82,8 +82,8 @@ macro_rules! test_simple_bgcolor {
 }
 
 mod compat_bgcolors {
-    use super::ansi_term;
-    use super::ansi_term::*;
+    use super::ansiterm;
+    use super::ansiterm::*;
     use super::colored;
     use super::colored::*;
 
@@ -98,8 +98,8 @@ mod compat_bgcolors {
 }
 
 mod compat_complex {
-    use super::ansi_term;
-    use super::ansi_term::*;
+    use super::ansiterm;
+    use super::ansiterm::*;
     use super::colored;
     use super::colored::*;
 
@@ -125,8 +125,8 @@ mod compat_complex {
 }
 
 mod compat_overrides {
-    use super::ansi_term;
-    use super::ansi_term::*;
+    use super::ansiterm;
+    use super::ansiterm::*;
     use super::colored;
     use super::colored::*;
 


### PR DESCRIPTION
ansi_term hasn't been maintained since 2019, so switch to the maintained fork